### PR TITLE
Dataloader bug

### DIFF
--- a/sat_pred/dataloader.py
+++ b/sat_pred/dataloader.py
@@ -57,7 +57,9 @@ def find_valid_t0_times(ds, history_mins, forecast_mins, sample_freq_mins):
     for _, row in contiguous_t0_periods.iterrows():
         start_dt = row["start_dt"]
         end_dt = row["end_dt"]
-        valid_t0_times.append(pd.date_range(row["start_dt"], row["end_dt"], freq="5min"))
+        valid_t0_times.append(
+            pd.date_range(row["start_dt"], row["end_dt"],  freq=f"{sample_freq_mins}min")
+        )
 
     valid_t0_times = pd.to_datetime(np.concatenate(valid_t0_times))
     

--- a/sat_pred/dataloader.py
+++ b/sat_pred/dataloader.py
@@ -55,10 +55,12 @@ def find_valid_t0_times(ds, history_mins, forecast_mins, sample_freq_mins):
 
     valid_t0_times = []
     for _, row in contiguous_t0_periods.iterrows():
-        start_dt = row["start_dt"]
-        end_dt = row["end_dt"]
         valid_t0_times.append(
-            pd.date_range(row["start_dt"], row["end_dt"],  freq=f"{sample_freq_mins}min")
+            pd.date_range(
+                row["start_dt"], 
+                row["end_dt"],  
+                freq=f"{sample_freq_mins}min"
+            )
         )
 
     valid_t0_times = pd.to_datetime(np.concatenate(valid_t0_times))

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -33,6 +33,21 @@ def test_find_valid_t0_times(sat_zarr_path):
     # Total                               252
     
     assert len(t0_times)==252
+    
+    t0_times = find_valid_t0_times(
+        ds, 
+        history_mins=60, 
+        forecast_mins=120, 
+        sample_freq_mins=15,
+    )
+    
+    # original 15 minute timesteps     288 / 3
+    # forecast length buffer      - (120 / 15) 
+    # history length buffer       -  (60 / 15) 
+    #                            ------------
+    # Total                               84
+    
+    assert len(t0_times)==84    
 
 
 def test_satellite_dataset(sat_zarr_path):


### PR DESCRIPTION
There was a mistake in the dataloader around the selection of forecast initialisation times. In the code we assume that if we are forecasting the satellite data with time frequency $t$ (e.g. 15 minutely) then the forecast initialisation times should be a multiple of $t$. There was a mistake in the `find_valid_t0_times()` function which did violated this assumption. 

It has now been fixed and a new test added which would have caught the mistake